### PR TITLE
add baseurl for correct section navigation

### DIFF
--- a/_includes/section-nav.html
+++ b/_includes/section-nav.html
@@ -1,7 +1,7 @@
 <div class="section-nav">
   <div class="left align-right">
     {% if page.prev_section != null %}
-      <a href="/docs/{{page.prev_section}}/" class="prev">
+      <a href="{{site.baseurl}}/docs/{{page.prev_section}}/" class="prev">
         Back
       </a>
     {% else %}
@@ -10,7 +10,7 @@
   </div>
   <div class="right align-left">
     {% if page.next_section != null %}
-      <a href="/docs/{{page.next_section}}/" class="next">
+      <a href="{{site.baseurl}}/docs/{{page.next_section}}/" class="next">
         Next
       </a>
     {% else %}


### PR DESCRIPTION
The navigation between two docs pages does only work when starting up jekyll locally but is not working for a subdomain.
