### PR TITLE
Orcas doesn't remove default maxvalue of sequence if cycling is enabled

### DIFF
--- a/orcas_core/build_source/orcas_diff/src/main/java/de/opitzconsulting/orcas/diff/InitDiffRepository.java
+++ b/orcas_core/build_source/orcas_diff/src/main/java/de/opitzconsulting/orcas/diff/InitDiffRepository.java
@@ -379,6 +379,18 @@ public class InitDiffRepository
         return lReturn;
       }
 
+      @Override
+      public void cleanupValues( Sequence pValue ) {
+        BigInteger tmpMaxvalue = pValue.getMaxvalue();
+
+        super.cleanupValues( pValue );
+
+        if ( pValue.getCycle() == CycleType.CYCLE && pValue.getMaxvalue() == null )
+        {
+          pValue.setMaxvalue( tmpMaxvalue );
+        }
+      }
+
       public BigInteger cacheCleanValueIfNeeded( BigInteger pValue )
       {
         if (Objects.equals(pValue, BigInteger.valueOf(20))) {

--- a/orcas_core/build_source/orcas_xslt_extract/xslt_extract/orcas_extract.xsl
+++ b/orcas_core/build_source/orcas_xslt_extract/xslt_extract/orcas_extract.xsl
@@ -103,11 +103,8 @@
   </template>
 
   <template match="maxvalue[parent::Sequence]">
-    <!-- der 999... Wert ist der Default, macht ausserdem bei xtext Probleme, da er zu lang ist -->
-    <if test=". != '9999999999999999999999999999'">
-      <text> maxvalue </text>
-      <value-of select="." />
-    </if>
+    <text> maxvalue </text>
+    <value-of select="." />
   </template>
 
   <template match="minvalue">

--- a/orcas_core/xslt_extract/orcas_extract.xsl
+++ b/orcas_core/xslt_extract/orcas_extract.xsl
@@ -103,11 +103,8 @@
   </template>
 
   <template match="maxvalue[parent::Sequence]">
-    <!-- der 999... Wert ist der Default, macht ausserdem bei xtext Probleme, da er zu lang ist -->
-    <if test=". != '9999999999999999999999999999'">
-      <text> maxvalue </text>
-      <value-of select="." />
-    </if>
+    <text> maxvalue </text>
+    <value-of select="." />
   </template>
 
   <template match="minvalue">


### PR DESCRIPTION
Simple Bugfix